### PR TITLE
Add a CICD-dummy-mode

### DIFF
--- a/ruby/create_volume.rb
+++ b/ruby/create_volume.rb
@@ -22,6 +22,7 @@ software_file=nil
 reponame=nil
 supp_file = nil
 supp_name = nil
+cicd_mode = false
 
 OptionParser.new do |parser|
   parser.banner = "Usage: create_volume.rb -v VOLUME -b BIBFILE [optional]"
@@ -58,6 +59,10 @@ OptionParser.new do |parser|
             "A csv file containing information about supplementary label") do |label|
     supp_name=label
   end
+  parser.on("-c", "--[no-]cicd-mode",
+            "Validate bibfile only. Will not produce a valid website, but does not require pdfs.") do |cicd|
+    cicd_mode=cicd
+  end
 
 end.parse!
 
@@ -83,9 +88,8 @@ MLResearch.write_volume_files(volume_info)
 # Write the papers
 directory_name = "_posts"
 Dir.mkdir(directory_name) unless File.exists?(directory_name)
-MLResearch.extractpapers(bib_file, volume_no, volume_info, software_file, video_file, supp_file, supp_name)  
+MLResearch.extractpapers(bib_file, volume_no, volume_info, software_file, video_file, supp_file, supp_name, cicd_mode)
 out = File.open('index.html', 'w')
 out.puts "---"
 out.puts "layout: home"
 out.puts "---"
-

--- a/ruby/mlresearch.rb
+++ b/ruby/mlresearch.rb
@@ -351,6 +351,7 @@ module MLResearch
       #puts ha['author'][0]['family'] + published.year.to_s.slice(-2,-1) + 'a'
       #puts ha['id']
 
+      # cicd_mode ignores pdfs since they will generally not be available.
       if not cicd_mode
         # True for volumes that didn't necessarily conform to original layout
         inc_layout = ([27..53] + [55..56] + [63..64]).include?(volume_no.to_i)


### PR DESCRIPTION
We want to validate Submission-bibfiles automatically via CICD over in mlresearch/pmlr-submssions. pdfs will generally not be available to do that, given the github size constraints.